### PR TITLE
adjust icon size within button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Updated
 
-- Update themes to use fontSize 1.125rem for startIcons and endIcons in buttons ([#24](https://github.com/etn-ccis/blui-react-themes/issues/24)).
+-  Update themes to use fontSize 1.125rem for startIcons and endIcons in buttons ([#24](https://github.com/etn-ccis/blui-react-themes/issues/24)).
 
 ## v7.1.0 (November 30, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v7.2.0 (not released)
+
+### updated
+
+- Update themes to use fontSize 1.125rem for startIcons and endIcons in buttons ([#24](https://github.com/etn-ccis/blui-react-themes/issues/24)).
+
 ## v7.1.0 (November 30, 2022)
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v7.2.0 (not released)
 
-### updated
+### Updated
 
 - Update themes to use fontSize 1.125rem for startIcons and endIcons in buttons ([#24](https://github.com/etn-ccis/blui-react-themes/issues/24)).
 

--- a/src/blueDarkTheme.ts
+++ b/src/blueDarkTheme.ts
@@ -169,6 +169,11 @@ export const blueDarkTheme = createTheme({
                         backgroundColor: BLUIColors.black[400],
                     },
                 },
+                iconSizeMedium: {
+                    "& > *:nth-of-type(1)": {                  
+                      fontSize: "1.125rem",
+                  },
+                },
                 outlined: {
                     borderColor: BLUIColors.black[200],
                     "&:hover": {

--- a/src/blueTheme.ts
+++ b/src/blueTheme.ts
@@ -131,7 +131,7 @@ export const blueTheme = createTheme({
                 },
                 iconSizeMedium: {
                     "& > *:nth-of-type(1)": {                  
-                      fontSize: 18,
+                      fontSize: "1.125rem",
                   },
                 },
                 contained: {

--- a/src/blueTheme.ts
+++ b/src/blueTheme.ts
@@ -129,6 +129,11 @@ export const blueTheme = createTheme({
                 root: {
                     textTransform: "none",
                 },
+                iconSizeMedium: {
+                    "& > *:nth-of-type(1)": {                  
+                      fontSize: 18,
+                  },
+                },
                 contained: {
                     backgroundColor: ThemeColors.background.paper,
                     color: ThemeColors.text.primary,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-react-themes/issues/24.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- update both themes to use 1.125rem (18px) for startIcon & endIcon in buttons

<!-- Include screenshots if they will help illustrate the changes in this PR -->
Before:
<img width="410" alt="image" src="https://user-images.githubusercontent.com/119693939/211904720-c8193fd6-19f6-4a51-bb7b-f4ac9fa8aa0a.png">

After:
<img width="424" alt="image" src="https://user-images.githubusercontent.com/119693939/211904838-6b0578fa-2141-4511-99a0-042216c64bda.png">
<img width="474" alt="image" src="https://user-images.githubusercontent.com/119693939/211904888-4ff03bd0-ca8b-4459-ae8e-b47d0fad1d41.png">


#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- clone repo
- git checkout feature/adjust-icon-size
- yarn start
- verify any button with startIcon or endIcon

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
