### PR TITLE
MUI Avatar dark mode style issue

### DIFF
--- a/src/componentStylesOverrides/MuiAvatar.ts
+++ b/src/componentStylesOverrides/MuiAvatar.ts
@@ -1,19 +1,10 @@
 import { Components, CssVarsTheme, Theme } from "@mui/material/styles";
 
-import { BLUIColors } from "@brightlayer-ui/colors";
-import Color from "color";
-
 export default {
     styleOverrides: {
         colorDefault: ({ theme }) => ({
             backgroundColor: theme.vars.palette.primary.light,
             color: theme.vars.palette.primary.main,
-            ...theme.applyStyles("dark", {
-                backgroundColor: Color(BLUIColors.black[50])
-                    .alpha(0.1)
-                    .string(),
-                color: theme.vars.palette.text.primary,
-            }),
         }),
     },
 } as Components<


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # .
- Fixed MUI avatar dark mode issue #107 

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
<img width="1840" alt="Screenshot 2024-11-13 at 4 18 06 PM" src="https://github.com/user-attachments/assets/8fa89837-08ac-4b8b-9f26-54c8f53af79f">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- cd demo/showcase
- yarn add @mui/codemod @mui/docs @mui/envinfo @mui/icons-material @mui/lab @mui/material @mui/private-theming @mui/styled-engine @mui/styled-engine-sc @mui/styles @mui/system @mui/types @mui/x-date-pickers
- yarn start
- Open RTLProvider.tsx
- import -> import {blueThemes} from '@brightlayer-ui/react-themes'
- Replace theme provider -> <ThemeProvider theme={blueThemes} defaultMode='light' >

