### PR TITLE
BLUI-6433 Fixed chip background and text disabled color

### DIFF
--- a/src/componentStylesOverrides/MuiChip.ts
+++ b/src/componentStylesOverrides/MuiChip.ts
@@ -27,7 +27,7 @@ export default {
             },
             "&.Mui-disabled": {
                 opacity: 1,
-                color: `rgba(${theme.vars.palette.text.primary} / 0.3)`,
+                color: theme.vars.palette.action.disabled,
                 "& .MuiChip-avatar": {
                     opacity: 0.5,
                 },
@@ -291,11 +291,17 @@ export default {
                     color: "inherit",
                 },
                 "&.MuiChip-outlinedPrimary": {
-                    backgroundColor: `rgba(${theme.vars.palette.primary.dark} / 0.2)`,
-                    border: `1px solid rgba(${theme.vars.palette.primary.dark} / 0.2)`,
+                    backgroundColor: Color(BLUIColors.blue[400])
+                        .alpha(0.2)
+                        .string(),
+                    border: `1px solid ${Color(BLUIColors.blue[400])
+                        .alpha(0.2)
+                        .string()}`,
                     color: theme.vars.palette.primary.main,
                     "&.MuiChip-clickable:hover": {
-                        backgroundColor: `rgba(${theme.vars.palette.primary.dark} / 0.3)`,
+                        backgroundColor: Color(BLUIColors.blue[500])
+                            .alpha(0.4)
+                            .string(),
                     },
                     "& .MuiChip-deleteIconOutlinedColorPrimary": {
                         color: BLUIColors.blue[400],
@@ -316,11 +322,15 @@ export default {
                     },
                 },
                 "&.MuiChip-outlinedSecondary": {
-                    backgroundColor: `rgba(${theme.vars.palette.secondary.main} / 0.2)`,
+                    backgroundColor: Color(BLUIColors.blue[300])
+                        .alpha(0.25)
+                        .string(),
                     border: `1px solid ${theme.vars.palette.secondary.main}`,
                     color: theme.vars.palette.secondary.main,
                     "&.MuiChip-clickable:hover": {
-                        backgroundColor: `rgba(${theme.vars.palette.secondary.dark} / 0.3)`,
+                        backgroundColor: Color(BLUIColors.blue[600])
+                            .alpha(0.4)
+                            .string(),
                     },
                     "& .MuiChip-deleteIconOutlinedColorSecondary": {
                         color: BLUIColors.lightBlue[400],


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # .
- https://github.com/etn-ccis/blui-react-themes/issues/122

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- 
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
<img width="418" alt="Screenshot 2025-01-07 at 3 24 56 PM" src="https://github.com/user-attachments/assets/961bcdff-fdc9-4f46-ada4-fb279f3f0a78" />
<img width="407" alt="Screenshot 2025-01-07 at 3 25 29 PM" src="https://github.com/user-attachments/assets/5cd94162-4476-41c4-9bbe-f71d8dd11ca6" />



<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- delete  showcase folder's node modules and yarn.lock
- run command "yarn cache clean" on demo showcase
- yarn start at root project

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
