### PR TITLE
added outline for primary chip in dark mode

### DIFF
--- a/src/componentStylesOverrides/MuiChip.ts
+++ b/src/componentStylesOverrides/MuiChip.ts
@@ -1,6 +1,7 @@
 import { Components, Theme, CssVarsTheme } from "@mui/material/styles";
 import * as BLUIColors from "@brightlayer-ui/colors";
 import Color from "color";
+import { theme } from "..";
 
 const WhiteText = BLUIColors.white[50];
 const Spacing = 8;
@@ -307,9 +308,8 @@ export default {
                     backgroundColor: Color(BLUIColors.blue[400])
                         .alpha(0.2)
                         .string(),
-                    border: `1px solid ${Color(BLUIColors.blue[400])
-                        .alpha(0.2)
-                        .string()}`,
+                    border: `1px solid ${theme.vars.palette.primary.main}`,
+                     
                     color: theme.vars.palette.primary.main,
                     "&.MuiChip-clickable:hover": {
                         backgroundColor: Color(BLUIColors.blue[500])


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes  https://github.com/etn-ccis/blui-react-themes/issues/128.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- updated MuiChips.ts
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- Before : 

![image](https://github.com/user-attachments/assets/4d275b08-c78d-47e0-9d05-b1b9240c4515)


- After Fix : 
![image](https://github.com/user-attachments/assets/de163cae-d8cb-464e-9598-e423cc94fd5b)



<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Go to Chip (Outline) section in  Data Display  of Material-UI components
- change the theme to dark theme
- check Primary Chip (Outline) has border now.

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
