### PR TITLE
fixed leading icon size issue for chips in dark mode

### DIFF
--- a/src/componentStylesOverrides/MuiChip.ts
+++ b/src/componentStylesOverrides/MuiChip.ts
@@ -376,6 +376,12 @@ export default {
                 marginLeft: Spacing,
                 marginRight: -4,
             }),
+            ...theme.applyStyles("dark", {
+                fontSize: "1.125rem",
+                color: theme.vars.palette.text.primary,
+                marginLeft: Spacing,
+                marginRight: -4,
+            }),
         }),
     },
 } as Components<


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-react-themes/issues/66 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Fixed leading icon size for chips in dark mode.

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-Before:
In Default theme leading icon size is correct : 
![image](https://github.com/user-attachments/assets/6483a3a2-09fe-4814-bef0-f588df9946d4)
In Dark theme wrong leading icon size :
![image](https://github.com/user-attachments/assets/d784895c-d0e4-46b8-b2a6-834820359130)

- After Fix:   same as default theme
![image](https://github.com/user-attachments/assets/cacd895b-3a7f-44e4-97ff-f3ba24ddf4dc)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Go to Data display section in Material UI Data Display.
- Go to Chip section and change the theme to dark mode. 
- Check the leading icon size in chip , it should be same as default theme now.


<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
